### PR TITLE
Update tensorflow simplex to support version 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # simplexnoise
-python implementation of 3d simplex noise
+
+Python implementation of 3d simplex noise
+
+Forked and modified from the original to be compatible with Tensorflow 2.0 with minimal changes
+

--- a/README.md
+++ b/README.md
@@ -2,5 +2,4 @@
 
 Python implementation of 3d simplex noise
 
-Forked and modified from the original to be compatible with Tensorflow 2.0 with minimal changes
-
+Note: Tensorflow implementation now compatible with verseion 2.x and may not work with 1.x versions.

--- a/numpy-simplex-matrix.py
+++ b/numpy-simplex-matrix.py
@@ -81,11 +81,14 @@ def matrix_noise3d(input_vectors, perm, grad3):
 
 
 if __name__ == "__main__":
-    shape = (3840, 2160)
+    shape = (512, 512)
     phases = 5
     scaling = 200.0
     input_vectors = get_input_vectors(shape, phases, scaling)
-    num_steps_benchmark = 1
+    num_steps_burn_in = 10
+    num_steps_benchmark = 20
+    for i in range(num_steps_burn_in):
+        raw_noise = matrix_noise3d(input_vectors, np_perm, np_grad3)
     start_time = time()
     for i in range(num_steps_benchmark):
         raw_noise = matrix_noise3d(input_vectors, np_perm, np_grad3)

--- a/numpy-simplex-matrix.py
+++ b/numpy-simplex-matrix.py
@@ -81,14 +81,11 @@ def matrix_noise3d(input_vectors, perm, grad3):
 
 
 if __name__ == "__main__":
-    shape = (512, 512)
+    shape = (3840, 2160)
     phases = 5
     scaling = 200.0
     input_vectors = get_input_vectors(shape, phases, scaling)
-    num_steps_burn_in = 10
-    num_steps_benchmark = 20
-    for i in range(num_steps_burn_in):
-        raw_noise = matrix_noise3d(input_vectors, np_perm, np_grad3)
+    num_steps_benchmark = 1
     start_time = time()
     for i in range(num_steps_benchmark):
         raw_noise = matrix_noise3d(input_vectors, np_perm, np_grad3)

--- a/numpy-simplex-naive.py
+++ b/numpy-simplex-naive.py
@@ -78,14 +78,15 @@ def np_noise3d(v):
 
 
 if __name__ == "__main__":
-    shape = (512, 512)
+    shape = (1000, 512)
     phases = 5
     scaling = 200.0
     input_vectors = get_input_vectors(shape, phases, scaling)
     raw_noise = np.empty(input_vectors.shape[0], dtype=np.float32)
     start_time = time()
-    for i in range(0, input_vectors.shape[0]):
+    for i in range(input_vectors.shape[0]):
         raw_noise[i] = np_noise3d(input_vectors[i])
-    print("The calculation took " + str(time() - start_time) + " seconds.")
+    end_time = time()
+    print("The calculation took {:.4} seconds.".format((end_time - start_time) / input_vectors.shape[0]))
     image_data = sum_phases(raw_noise, phases, shape)
     show(image_data)

--- a/numpy-simplex-naive.py
+++ b/numpy-simplex-naive.py
@@ -78,7 +78,7 @@ def np_noise3d(v):
 
 
 if __name__ == "__main__":
-    shape = (1000, 512)
+    shape = (512, 512)
     phases = 5
     scaling = 200.0
     input_vectors = get_input_vectors(shape, phases, scaling)
@@ -86,7 +86,6 @@ if __name__ == "__main__":
     start_time = time()
     for i in range(input_vectors.shape[0]):
         raw_noise[i] = np_noise3d(input_vectors[i])
-    end_time = time()
-    print("The calculation took {:.4} seconds.".format((end_time - start_time) / input_vectors.shape[0]))
+    print("The calculation took " + str(time() - start_time) + " seconds.")
     image_data = sum_phases(raw_noise, phases, shape)
     show(image_data)

--- a/tensor-flow-simplex-matrix.py
+++ b/tensor-flow-simplex-matrix.py
@@ -128,22 +128,17 @@ def calculate_image(noise_values, phases, shape):
 
 
 if __name__ == "__main__":
-
-    print('is executing eagerly:', tf.executing_eagerly())
-
-    shape = [3840, 2160]
-    phases = 5
+    shape = (512, 512)
+    phases = 10
     scaling = 200.0
     offset = (0.0, 0.0, 1.7)
     v_shape = tf.constant(shape, name='shape')
-    v_phases = tf.constant(5, name='phases')
-    v_scaling = tf.constant(200.0, name='scaling')
-    v_offset = tf.constant([0.0, 0.0, 1.7], name='offset')
+    v_phases = tf.constant(phases, name='phases')
+    v_scaling = tf.constant(scaling, name='scaling')
+    v_offset = tf.constant(offset, name='offset')
     v_input_vectors = get_input_vectors(v_shape, v_phases, v_scaling, v_offset)
     perm = tf.constant(np_perm, name='perm')
     grad3 = tf.constant(np_grad3, name='grad3')
-    num_steps_burn_in = 10
-    num_steps_benchmark = 20
     vertex_table = tf.constant(np_vertex_table, name='vertex_table')
     start_time = time()
     raw_noise = noise3d(v_input_vectors, perm, grad3, vertex_table, shape[0] * shape[1] * phases)
@@ -153,4 +148,12 @@ if __name__ == "__main__":
     input_vectors = get_input_vectors(shape, phases, scaling, offset)
     noise = noise3d(input_vectors, np_perm, np_grad3, np_vertex_table, shape[0] * shape[1] * phases)
     image_data = calculate_image(noise, phases, shape)
+    show(image_data.numpy().astype(np.uint8))
+
+    # Custom vector repeating the top quarter of the image 4 times
+    base_values = input_vectors[0:int(input_vectors.shape[0] / 4)]
+    input_vectors = tf.tile(base_values, [4, 1])
+    noise = noise3d(input_vectors, np_perm, np_grad3, np_vertex_table, shape[0] * shape[1] * phases)
+    image_data = calculate_image(noise, phases, shape)
+
     show(image_data.numpy().astype(np.uint8))

--- a/tf_get_simplex_vertices.py
+++ b/tf_get_simplex_vertices.py
@@ -45,7 +45,4 @@ if __name__ == "__main__":
     test_offsets = tf.constant([[0.2, 0.1, 0.3], [0.03, 0.15, 0.12],
                                 [0.34, 0.21, 0.31], [0.49, 0.0012, 0.237]], name="offsets")
     verts = get_simplex_vertices(test_offsets, vertex_table, 4)
-    init = tf.initialize_all_variables()
-    sess = tf.Session()
-    sess.run(init)
-    print(sess.run(tf.to_int32(verts[:, 0, 1])))
+    print(verts)

--- a/tf_get_simplex_vertices.py
+++ b/tf_get_simplex_vertices.py
@@ -14,32 +14,35 @@ vertex_options = np.array([
 ], dtype=np.float32)
 
 # Dimesions are: x0 >= y0, y0 >= z0, x0 >= z0
-np_vertex_table = np.array([
+# np_vertex_table = np.array([
+tf_vertex_table = tf.convert_to_tensor([
     [[vertex_options[3], vertex_options[3]],
      [vertex_options[4], vertex_options[5]]],
     [[vertex_options[2], vertex_options[1]],
      [vertex_options[2], vertex_options[0]]]
-], dtype=np.float32)
+], dtype=tf.float32)
 
 
 def get_simplex_vertices(offsets, vertex_table, length):
-    vertex_table_x_index = tf.to_int32(offsets[:, 0] >= offsets[:, 1])
-    vertex_table_y_index = tf.to_int32(offsets[:, 1] >= offsets[:, 2])
-    vertex_table_z_index = tf.to_int32(offsets[:, 0] >= offsets[:, 2])
-    index_list = tf.concat(1, [
-        tf.reshape(tf.tile(tf.concat(1, [
+    vertex_table_x_index = tf.cast((offsets[:, 0] >= offsets[:, 1]), tf.int32)
+    vertex_table_y_index = tf.cast((offsets[:, 1] >= offsets[:, 2]), tf.int32)
+    vertex_table_z_index = tf.cast((offsets[:, 0] >= offsets[:, 2]), tf.int32)
+
+    index_list = tf.concat([
+        tf.reshape(tf.tile(tf.concat([
             tf.expand_dims(vertex_table_x_index, 1),
             tf.expand_dims(vertex_table_y_index, 1),
             tf.expand_dims(vertex_table_z_index, 1),
-        ]), [1, 6]), [6 * length, 3]),
-        tf.expand_dims(tf.tile(tf.range(0, limit=6), [length]), 1)])
+        ], 1), [1, 6]), [6 * length, 3]),
+        tf.expand_dims(tf.tile(tf.range(0, limit=6), [length]), 1)], 1)
     vertices = tf.reshape(tf.gather_nd(vertex_table, index_list), [-1, 2, 3])
     return vertices
 
 
 if __name__ == "__main__":
-    vertex_table = tf.Variable(np_vertex_table, name='vertex_table')
-    test_offsets = tf.Variable([[0.2, 0.1, 0.3], [0.03, 0.15, 0.12],
+
+    vertex_table = tf.constant(tf_vertex_table, name='vertex_table')
+    test_offsets = tf.constant([[0.2, 0.1, 0.3], [0.03, 0.15, 0.12],
                                 [0.34, 0.21, 0.31], [0.49, 0.0012, 0.237]], name="offsets")
     verts = get_simplex_vertices(test_offsets, vertex_table, 4)
     init = tf.initialize_all_variables()

--- a/tf_input.py
+++ b/tf_input.py
@@ -11,16 +11,17 @@ def tf_repeat(x, num_repeats):
 
 
 def get_input_vectors(shape, phases, scaling, offset):
-    x = tf.reshape(tf_repeat(offset[0] + tf.linspace(0.0, tf.to_float(shape[0] - 1), shape[0]) / scaling,
+    x = tf.reshape(tf_repeat(offset[0] + tf.linspace(0.0, float(shape[0]) - 1., shape[0]) / float(scaling),
                              shape[1] * phases),
-                   [shape[0], shape[1], phases]) * tf.pow(2.0, tf.linspace(0.0, tf.to_float(phases - 1), phases))
+                   [shape[0], shape[1], phases]) * tf.pow(2.0, tf.linspace(0.0, float(phases) - 1., phases))
     y = tf.reshape(tf_repeat(tf.tile(
-        offset[1] + tf.linspace(0.0, tf.to_float(shape[1] - 1), shape[1]) / scaling,
+        offset[1] + tf.linspace(0.0, float(shape[1]) - 1., shape[1]) / scaling,
         [shape[0]]
-    ), phases), [shape[0], shape[1], phases]) * tf.pow(2.0, tf.linspace(0.0, tf.to_float(phases - 1), phases))
+    ), phases), [shape[0], shape[1], phases]) * tf.pow(2.0, tf.linspace(0.0, float(phases) - 1., phases))
     z = tf.reshape(
-        tf.tile(offset[2] + 10 * tf.linspace(0.0, tf.to_float(phases - 1), phases), [shape[0] * shape[1]]),
+        tf.tile(offset[2] + 10. * tf.linspace(0.0, float(phases) - 1., phases), [shape[0] * shape[1]]),
         [shape[0], shape[1], phases, 1])
     x = tf.reshape(x, [shape[0], shape[1], phases, 1])
     y = tf.reshape(y, [shape[0], shape[1], phases, 1])
-    return tf.reshape(tf.concat(3, [x, y, z]), [shape[0] * shape[1] * phases, 3])
+
+    return tf.reshape(tf.concat([x, y, z], 3), [shape[0] * shape[1] * phases, 3])

--- a/tf_map_gradient.py
+++ b/tf_map_gradient.py
@@ -22,8 +22,4 @@ if __name__ == "__main__":
     gradient_map = tf.constant(np_grad3, name='vertex_table')
     gis = tf.Variable([0, 3, 7, 2, 9, 11, 7, 4], name="gis")
     gradients = map_gradients(gradient_map, gis, 8)
-    # init = tf.initialize_all_variables()
-    # sess = tf.Session()
-    # sess.run(init)
-    # print(sess.run(gradients))
     print(gradients)

--- a/tf_map_gradient.py
+++ b/tf_map_gradient.py
@@ -11,18 +11,19 @@ np_grad3 = np.array([[1, 1, 0], [-1, 1, 0], [1, -1, 0], [-1, -1, 0],
 
 
 def map_gradients(gradient_map, gis, length):
-    index_tensor = tf.reshape(tf.concat(1, [
+    index_tensor = tf.reshape(tf.concat([
         tf.reshape(tf.tile(tf.expand_dims(gis, 1), [1, 3]), [length * 3, 1]),
         tf.expand_dims(tf.tile(tf.range(0, limit=3), [length]), 1)
-    ]), [length, 3, 2])
+    ], 1), [length, 3, 2])
     return tf.gather_nd(gradient_map, index_tensor)
 
 
 if __name__ == "__main__":
-    gradient_map = tf.Variable(np_grad3, name='vertex_table')
+    gradient_map = tf.constant(np_grad3, name='vertex_table')
     gis = tf.Variable([0, 3, 7, 2, 9, 11, 7, 4], name="gis")
     gradients = map_gradients(gradient_map, gis, 8)
-    init = tf.initialize_all_variables()
-    sess = tf.Session()
-    sess.run(init)
-    print(sess.run(gradients))
+    # init = tf.initialize_all_variables()
+    # sess = tf.Session()
+    # sess.run(init)
+    # print(sess.run(gradients))
+    print(gradients)


### PR DESCRIPTION
Update tensorflow simplex to support version 2.0.

Tried to keep example code relatively similar, but removed some of the burn-in iterations since it can run eagerly. I don't believe this code supports tensorflow 1.x, so if that's something you want, I can create separate files for 2.x.